### PR TITLE
Fix typo in lab1/part1/README.md

### DIFF
--- a/lab1/part1/README.md
+++ b/lab1/part1/README.md
@@ -96,12 +96,12 @@ A script is provided (capture_submission.sh) that you run in two parts.
 Do Part 1.  Then run
 
 ```
-./capture_submission part1
+./capture_submission.sh part1
 ```
 
 Then do Part 2.  Then run
 ```
-./capture_submission part2
+./capture_submission.sh part2
 ```
  
 


### PR DESCRIPTION
Add ".sh" to the lines 

```
./capture_submission part1
```

and 

```
./capture_submission part1
```

in lab1/part1/README.md.