### PR TITLE
Fix exabgp docker image typo

### DIFF
--- a/demo3-exabgp/diamond-mod2.clab.yml
+++ b/demo3-exabgp/diamond-mod2.clab.yml
@@ -5,7 +5,7 @@ topology:
   nodes:
     lan1:
       kind: linux
-      image: exagbp
+      image: exabgp
       binds:
         - mod2-bird-confs:/etc/bird-alt/
       entrypoint: /bin/bash


### PR DESCRIPTION
Corrects a typo in the containerlab configuration
by changing the local docker image name from exagbp to exabgp, as specified in the README for demo3.

This resolves an error with containerlab deploy.